### PR TITLE
Note required python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ The current validity status of several popular STAC API implementations can be f
 
 ## Validating STAC API conformance
 
-Create new venv:
+Create new venv with python >= 3.9:
 
 ```
-python -m venv --prompt stac-api-validator .venv
+python3.9 -m venv --prompt stac-api-validator .venv
 source ./.venv/bin/activate
 ```
 


### PR DESCRIPTION
This PR adds the required python version to the README. I tried 3.6 and 3.8 with different sorts of errors before bumping to 3.9, which is the first one that was successful. I assume 3.10 is also fine though I haven't tried it. It might be nice as well to publish a container so that people don't have to guess.

I have no idea what the bottom diff is -- I've stared at it but they look the same to me 🤔