### PR TITLE
Don't warn re: version from extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Don't warn about old versions for extensions ([#365](https://github.com/stac-utils/stac-api-validator/pull/365))
+
 ## [0.6.1] - 2023-04-24
 
 ### Changed
@@ -152,7 +158,8 @@ Release is primarily to publish to Read the Docs as a version.
 
 - Fixed issue with item-search validation relying on collections behavior
 
-[unreleased]: https://github.com/stac-utils/stac-api-validator/compare/v0.6.0...main
+[unreleased]: https://github.com/stac-utils/stac-api-validator/compare/v0.6.1...main
+[0.6.1]: https://github.com/stac-utils/stac-api-validator/tree/v0.6.1
 [0.6.0]: https://github.com/stac-utils/stac-api-validator/tree/v0.6.0
 [0.5.0]: https://github.com/stac-utils/stac-api-validator/tree/v0.5.0
 [0.4.3]: https://github.com/stac-utils/stac-api-validator/tree/v0.4.3

--- a/src/stac_api_validator/validations.py
+++ b/src/stac_api_validator/validations.py
@@ -447,7 +447,7 @@ def validate_core_landing_page_body(
             x
             for x in conforms_to
             if re.match(
-                r"https://api\.stacspec\.org/v1\.0\.0.*/(core|item-search|ogcapi-features|collections)",
+                r"^https://api\.stacspec\.org/v1\.0\.0.*/(core|item-search|ogcapi-features|collections)$",
                 x,
             )
             and not x.startswith(LATEST_STAC_API_FOUNDATION_VERSION)

--- a/tests/test_landing_page.py
+++ b/tests/test_landing_page.py
@@ -1,5 +1,8 @@
+import copy
 from typing import Any
 from typing import Dict
+
+import pytest
 
 from stac_api_validator.validations import Errors
 from stac_api_validator.validations import Warnings
@@ -151,3 +154,56 @@ def test_landing_page_1() -> None:
     assert "CORE-8" not in errors
 
     # todo: item-search
+
+
+@pytest.fixture
+def perfect_core_landing_page() -> Dict[str, Any]:
+    return copy.deepcopy(
+        {
+            "conformsTo": [
+                "https://api.stacspec.org/v1.0.0/core",
+                "https://api.stacspec.org/v1.0.0/collections",
+                "https://api.stacspec.org/v1.0.0/ogcapi-features",
+            ],
+            "links": [
+                {"rel": "data", "href": "http://stac-api-validator.test/collections"}
+            ],
+        }
+    )
+
+
+def test_perfect_core_landing_page(perfect_core_landing_page: Dict[str, Any]) -> None:
+    errors = Errors()
+    warnings = Warnings()
+    validate_core_landing_page_body(
+        body=perfect_core_landing_page,
+        headers={"content-type": "application/json"},
+        errors=errors,
+        warnings=warnings,
+        conformance_classes=[],
+        collection=None,
+        geometry=None,
+    )
+    assert not errors
+    assert not warnings
+
+
+def test_perfect_core_landing_page_with_extension(
+    perfect_core_landing_page: Dict[str, Any]
+) -> None:
+    errors = Errors()
+    warnings = Warnings()
+    perfect_core_landing_page["conformsTo"].append(
+        "https://api.stacspec.org/v1.0.0-rc.3/ogcapi-features#fields",
+    )
+    validate_core_landing_page_body(
+        body=perfect_core_landing_page,
+        headers={"content-type": "application/json"},
+        errors=errors,
+        warnings=warnings,
+        conformance_classes=[],
+        collection=None,
+        geometry=None,
+    )
+    assert not errors
+    assert not warnings


### PR DESCRIPTION
The regex was hitting not-v1.0.0 extension urls.