### PR TITLE
Remove lockfile only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,5 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    versioning-strategy: lockfile-only
     allow:
       - dependency-type: "all"


### PR DESCRIPTION
There's a lot of dependabot noise on this repo ... I'm not sure the value of PATCH bumps in the lockfile, since our release cadence is pretty slow? I don't know if this CI fix will help but it might — I'm not super poetry-savvy.