### PR TITLE
Switch to pypi trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: release
+      url: https://pypi.org/p/stac-api-validator
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
@@ -57,17 +62,12 @@ jobs:
       - name: Publish package on PyPI
         if: steps.check-version.outputs.tag
         uses: pypa/gh-action-pypi-publish@v1.9.0
-        with:
-          user: ${{ secrets.PYPI_STACUTILS_USERNAME }}
-          password: ${{ secrets.PYPI_STACUTILS_PASSWORD}}
 
       - name: Publish package on TestPyPI
         if: "! steps.check-version.outputs.tag"
         uses: pypa/gh-action-pypi-publish@v1.9.0
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
 
       - name: Publish the release notes
         uses: release-drafter/release-drafter@v6.0.0


### PR DESCRIPTION
I've set up this workflow for trusted publishing in both PyPI and Test PyPI:

![image](https://github.com/user-attachments/assets/9b344687-bf05-4032-8897-28050ba80106)

I've also created a [release environment](https://github.com/stac-utils/stac-api-validator/settings/environments/3745299957/edit) as recommended by [the documentation](https://github.com/marketplace/actions/pypi-publish).

The [release workflow is currently broken](https://github.com/stac-utils/stac-api-validator/actions/runs/10472722416) and this _should_ fix.