### PR TITLE
Support STAC items without bbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 __pycache__/
 .ipynb_checkpoints/
 /.venv
+/node_modules/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,32 +7,12 @@ repos:
         language: system
         types: [python]
         require_serial: true
-      - id: check-added-large-files
-        name: Check for added large files
-        entry: check-added-large-files
-        language: system
-      - id: check-toml
-        name: Check Toml
-        entry: check-toml
-        language: system
-        types: [toml]
-      - id: check-yaml
-        name: Check Yaml
-        entry: check-yaml
-        language: system
-        types: [yaml]
       - id: darglint
         name: darglint
         entry: darglint
         language: system
         types: [python]
         stages: [manual]
-      - id: end-of-file-fixer
-        name: Fix End of Files
-        entry: end-of-file-fixer
-        language: system
-        types: [text]
-        stages: [commit, push, manual]
       - id: flake8
         name: flake8
         entry: flake8
@@ -54,14 +34,22 @@ repos:
         language: system
         types: [python]
         args: [--py37-plus]
-      - id: trailing-whitespace
-        name: Trim Trailing Whitespace
-        entry: trailing-whitespace-fixer
-        language: system
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-toml
+        types: [toml]
+      - id: check-yaml
+        types: [yaml]
+      - id: end-of-file-fixer
         types: [text]
-        stages: [commit, push, manual]
+        stages: [pre-commit, pre-push, manual]
+      - id: trailing-whitespace
+        types: [text]
+        stages: [pre-commit, pre-push, manual]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.6.0
+    rev: v3.1.0
     hooks:
       - id: prettier
   # - repo: https://github.com/pre-commit/mirrors-mypy

--- a/src/stac_api_validator/validations.py
+++ b/src/stac_api_validator/validations.py
@@ -3235,12 +3235,13 @@ def _validate_search_ids_with_ids_no_override(
     errors: Errors,
     r_session: Session,
 ) -> None:
-    bbox = item["bbox"]
+    bbox = item.get("bbox")
     get_params = {
         "ids": item["id"],
         "collections": item["collection"],
-        "bbox": f"{bbox[2] + 1},{bbox[3] + 1},{bbox[2] + 2},{bbox[3] + 2}",
     }
+    if bbox is not None:
+        get_params["bbox"] = f"{bbox[2] + 1},{bbox[3] + 1},{bbox[2] + 2},{bbox[3] + 2}"
 
     if Method.GET in methods:
         _, body, _ = retrieve(
@@ -3263,8 +3264,9 @@ def _validate_search_ids_with_ids_no_override(
         post_params = {
             "ids": [item["id"]],
             "collections": [item["collection"]],
-            "bbox": [bbox[2] + 1, bbox[3] + 1, bbox[2] + 2, bbox[3] + 2],
         }
+        if bbox is not None:
+            post_params["bbox"] = [bbox[2] + 1, bbox[3] + 1, bbox[2] + 2, bbox[3] + 2]
 
         _, body, _ = retrieve(
             Method.POST,


### PR DESCRIPTION
STAC items are not required to have a bbox, [the field is prohibited for items having no geometry](https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md#item-fields).

This PR allows to validate an API that returs such items.

Otherwise you face this error:

```
      Traceback (most recent call last):
        File "/home/vprivat/projects/env/lib/python3.12/site-packages/behave/model.py", line 1909, in run
          match.run(runner.context)
        File "/home/vprivat/projects/env/lib/python3.12/site-packages/behave/matchers.py", line 104, in run
          self.func(context, *args, **kwargs)
        File "features/steps/stac.py", line 158, in step_check_stac_api
          (warnings, errors) = validate_api(
                               ^^^^^^^^^^^^^
        File "/home/vprivat/projects/env/lib/python3.12/site-packages/stac_api_validator/validations.py", line 673, in validate_api
          validate_item_search(
        File "/home/vprivat/projects/env/lib/python3.12/site-packages/stac_api_validator/validations.py", line 1427, in validate_item_search
          validate_item_search_ids_does_not_override_all_other_params(
        File "/home/vprivat/projects/env/lib/python3.12/site-packages/stac_api_validator/validations.py", line 3343, in validate_item_search_ids_does_not_override_all_other_params
          _validate_search_ids_with_ids_no_override(
        File "/home/vprivat/projects/env/lib/python3.12/site-packages/stac_api_validator/validations.py", line 3238, in _validate_search_ids_with_ids_no_override
          bbox = item["bbox"]
                 ~~~~^^^^^^^^
      KeyError: 'bbox'
```