### PR TITLE
Provide http headers to pystac-client

### DIFF
--- a/src/stac_api_validator/validations.py
+++ b/src/stac_api_validator/validations.py
@@ -2799,7 +2799,7 @@ def validate_item_pagination(
 
     if use_pystac_client and collection is not None:
         try:
-            client = Client.open(root_url)
+            client = Client.open(root_url, headers=r_session.headers)
             search = client.search(
                 method="GET", collections=[collection], max_items=max_items, limit=5
             )
@@ -2872,7 +2872,7 @@ def validate_item_pagination(
         if use_pystac_client and collection is not None:
             max_items = 100
             try:
-                client = Client.open(root_url)
+                client = Client.open(root_url, headers=r_session.headers)
                 search = client.search(
                     method="POST",
                     collections=[collection],


### PR DESCRIPTION
Followup of #595 

Our STAC server requires authentication thanks to a custom `x-api-key` http header. Currently, we face this validation error:

`pystac-client threw exception while testing pagination {"code":"Unauthorized","description":"<our error message when the authentication header is missing>"}`

Indeed stac-api-validator performs two calls to [pystac-client](https://github.com/stac-utils/pystac-client) without providing the configured headers. This PR solves this.