### PR TITLE
Make --geometry optional for item-search conformance class

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ The conformance class validations to run are selected with the `--conformance` p
 can be used more than once to specify multiple conformance classes to validate. The `STAC API - Core` conformance
 class will always be validated, even if not specified.
 
-If `item-search`, `collections`, and/or `features` are specified, the `--collection` and `--geometry` parameters must also
-be specified. The `--collection` parameter specifies the name of a collection to use for some of the validations.
-The `--geometry` should specify an AOI over which there are between 100 and 20,000 results for the collection (more
+If `item-search`, `collections`, and/or `features` are specified, the `--collection` parameter must also
+be set. It specifies the name of a collection to use for some of the validations.
+The `--geometry` parameter should also be set to perform intersection tests.
+It should specify an AOI over which there are between 100 and 20,000 results for the collection (more
 results means longer time to run).
 
 ## Features
@@ -127,7 +128,7 @@ Options:
 Conformance classes item-search, features, and collections require the `--collection` parameter with the id of a
 collection to run some tests on.
 
-Conformance class `item-search` requires `--geometry` with a GeoJSON geometry that returns some items for
+Conformance class `item-search` supports `--geometry` with a GeoJSON geometry that returns some items for
 the specified collection.
 
 Example:


### PR DESCRIPTION
STAC allows items without geometry.

We have an application where all items are without geometry, thus when validating the `item-search` conformance class, having to provide one to perform intersection tests doesn't make sense, and it only spends time to perform tests doomed to fail.

This PR relaxes the necessity to specify a `--geometry` parameter for the `item-search` conformance class.

It still triggers a warning if the parameter is not set, as it still makes sense for the vast majority of STAC applications out there.